### PR TITLE
fix #19 return raw read data with length rcode

### DIFF
--- a/archiveinterface/archivebackends/hpss/hpss_backend_archive.py
+++ b/archiveinterface/archivebackends/hpss/hpss_backend_archive.py
@@ -129,7 +129,7 @@ class HpssBackendArchive(AbstractBackendArchive):
                     err_str = "Failed During HPSS Fread,"\
                               "return value is: " + str(rcode)
                     raise ArchiveInterfaceError(err_str)
-                return buf.value
+                return buf.raw[:rcode]
         except Exception as ex:
             err_str = "Can't read hpss file with error: " + str(ex)
             raise ArchiveInterfaceError(err_str)

--- a/archiveinterface/wsgi.py
+++ b/archiveinterface/wsgi.py
@@ -13,6 +13,7 @@ to support the new Backend Archie type
 from os import getenv
 from argparse import ArgumentParser
 from wsgiref.simple_server import make_server
+from archiveinterface.archive_utils import set_config_name
 from archiveinterface.archive_interface import ArchiveInterfaceGenerator
 from archiveinterface.archivebackends.archive_backend_factory import \
      ArchiveBackendFactory


### PR DESCRIPTION
### Description

This returns the raw data from hpss_fread and makes sure the length is rcode.
### Issues Resolved

#19 
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
