### PR TITLE
fix #28 add id2filename switch for posix backend archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ The final option is the application will default to config.cfg if neither of the
 Note here that the different backends use different config options.  These are required for their respected
 archive types.
 ```
+[posix]
+use_id2filename = false
+
 [hpss]
 user = hpss.unix
 auth = /var/hpss/etc/hpss.unix.keytab

--- a/archiveinterface/archive_interface_unit_tests.py
+++ b/archiveinterface/archive_interface_unit_tests.py
@@ -2,7 +2,7 @@
 """File used to unit test the pacifica archive interface."""
 import unittest
 import time
-from archiveinterface.archive_utils import un_abs_path, get_http_modified_time, read_config_value
+from archiveinterface.archive_utils import un_abs_path, get_http_modified_time, read_config_value, set_config_name
 from archiveinterface.id2filename import id2filename
 from archiveinterface.archivebackends.posix.extendedfile import ExtendedFile
 from archiveinterface.archivebackends.posix.posix_status import PosixStatus
@@ -198,6 +198,9 @@ class TestPosixBackendArchive(unittest.TestCase):
             self.assertTrue('Cant remove absolute path' in str(ex))
             hit_exception = True
         self.assertTrue(hit_exception)
+        set_config_name('test_configs/posix-id2filename.cfg')
+        my_file = backend.open(47, mode)
+        set_config_name('config.cfg')
 
     def test_posix_backend_close(self):
         """Test closing a file from posix backend."""

--- a/archiveinterface/archivebackends/posix/posix_backend_archive.py
+++ b/archiveinterface/archivebackends/posix/posix_backend_archive.py
@@ -6,7 +6,7 @@ backend.
 """
 
 import os
-from archiveinterface.archive_utils import un_abs_path
+from archiveinterface.archive_utils import un_abs_path, read_config_value
 from archiveinterface.archive_interface_error import ArchiveInterfaceError
 from archiveinterface.archivebackends.posix.extendedfile import ExtendedFile
 from archiveinterface.archivebackends.abstract.abstract_backend_archive \
@@ -37,7 +37,10 @@ class PosixBackendArchive(AbstractBackendArchive):
                       'one with error: ' + str(ex)
             raise ArchiveInterfaceError(err_str)
         try:
-            fpath = un_abs_path(filepath)
+            if read_config_value('posix', 'use_id2filename'):
+                fpath = un_abs_path(id2filename(int(filepath)))
+            else:
+                fpath = un_abs_path(str(filepath))
             filename = os.path.join(self._prefix, fpath)
             self._file = ExtendedFile(filename, mode)
             return self

--- a/archiveinterface/archivebackends/posix/posix_backend_archive.py
+++ b/archiveinterface/archivebackends/posix/posix_backend_archive.py
@@ -7,6 +7,7 @@ backend.
 
 import os
 from archiveinterface.archive_utils import un_abs_path, read_config_value
+from archiveinterface.id2filename import id2filename
 from archiveinterface.archive_interface_error import ArchiveInterfaceError
 from archiveinterface.archivebackends.posix.extendedfile import ExtendedFile
 from archiveinterface.archivebackends.abstract.abstract_backend_archive \

--- a/archiveinterface/archivebackends/posix/posix_backend_archive.py
+++ b/archiveinterface/archivebackends/posix/posix_backend_archive.py
@@ -38,10 +38,10 @@ class PosixBackendArchive(AbstractBackendArchive):
                       'one with error: ' + str(ex)
             raise ArchiveInterfaceError(err_str)
         try:
-            if read_config_value('posix', 'use_id2filename'):
+            if read_config_value('posix', 'use_id2filename') == 'true':
                 fpath = un_abs_path(id2filename(int(filepath)))
             else:
-                fpath = un_abs_path(str(filepath))
+                fpath = un_abs_path(filepath)
             filename = os.path.join(self._prefix, fpath)
             self._file = ExtendedFile(filename, mode)
             return self

--- a/config.cfg
+++ b/config.cfg
@@ -1,3 +1,6 @@
+[posix]
+use_id2filename = false
+
 [hpss]
 user = hpss.unix
 auth = /var/hpss/etc/hpss.unix.keytab

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 codeclimate-test-reporter
-coverage
+coverage>4,0,<4.4
 peewee
 pre-commit
 pylint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 codeclimate-test-reporter
-coverage>4,0,<4.4
+coverage>4.0,<4.4
 peewee
 pre-commit
 pylint

--- a/test_configs/posix-id2filename.cfg
+++ b/test_configs/posix-id2filename.cfg
@@ -1,0 +1,2 @@
+[posix]
+use_id2filename = true


### PR DESCRIPTION
### Description

Adds id2filename switch to config file for posix backend
### Issues Resolved

#28 
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
