### PR TITLE
fix #27 add mkdir -p options for open methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Modified header sets the mtime of the file in the archive and is
 required.
 
 ```
-curl -X PUT -H 'Last-Modified: Sun, 06 Nov 1994 08:49:37 GMT' --upload-file /tmp/foo.txt http://127.0.0.1:8080/1
+curl -X PUT -H 'Last-Modified: Sun, 06 Nov 1994 08:49:37 GMT' --upload-file /tmp/foo.txt http://127.0.0.1:8080/12345
 ```
 
 Sample output:
@@ -113,7 +113,7 @@ Sample output:
 The HTTP `GET` method is used to get the contents
 of the specified file.
 ```
-curl -o /tmp/foo.txt http://127.0.0.1:8080/1
+curl -o /tmp/foo.txt http://127.0.0.1:8080/12345
 ```
 Sample output (without -o option):
 "Document Contents"
@@ -125,7 +125,7 @@ status of the file. The status includes, but is not limited to, the
 size, mtime, ctime, whether its on disk or tape. The values can be found
 within the headers.
 ```
-curl -I -X HEAD http://127.0.0.1:8080/1
+curl -I -X HEAD http://127.0.0.1:8080/12345
 ```
 Sample output:
 ```
@@ -133,7 +133,7 @@ HTTP/1.0 204 No Content
 Date: Fri, 07 Oct 2016 19:51:37 GMT
 Server: WSGIServer/0.1 Python/2.7.5
 X-Pacifica-Messsage: File was found
-X-Pacifica-File: /tmp/foo.txt
+X-Pacifica-File: /tmp/12345
 Content-Length: 18
 Last-Modified: 1473806059.29
 X-Pacifica-Ctime: 1473806059.29
@@ -148,13 +148,13 @@ The HTTP `POST` method is used to stage a file for use.  In posix this
 equates to a no-op on hpss it stages the file to the disk drive.
 
 ```
-curl -X POST http://127.0.0.1:8080/1
+curl -X POST http://127.0.0.1:8080/12345
 ```
 
 Sample Output:
 ```
 {
-    "file": "/myemsl-dev/bundle/file.1",
+    "file": "/12345",
     "message": "File was staged"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ password = pass
 port = 3306
 ```
 
+# ID Mapping to File Names
+
+The Pacifica software depends on a flat ID space for indexing files. This needs
+to map to filenames on the backend storage in a nice way. To limit the number of
+files in a single directory (or number of directories in a directory) we use the
+algorithm in `archiveinterface.id2filename`. This takes a number and breaks it
+into bytes. Each byte is then represented in hex and used to build the directory
+tree.
+
+For example `id2filename(12345)` becomes `/39/3039` on the backend file system.
 
 # API Examples
 

--- a/archiveinterface/archive_interface_unit_tests.py
+++ b/archiveinterface/archive_interface_unit_tests.py
@@ -201,6 +201,7 @@ class TestPosixBackendArchive(unittest.TestCase):
 
         my_file = backend.open('/a/b/d', mode)
         set_config_name('test_configs/posix-id2filename.cfg')
+        backend = PosixBackendArchive('/tmp')
         my_file = backend.open(12345, mode)
         set_config_name('config.cfg')
 

--- a/archiveinterface/archive_interface_unit_tests.py
+++ b/archiveinterface/archive_interface_unit_tests.py
@@ -198,8 +198,10 @@ class TestPosixBackendArchive(unittest.TestCase):
             self.assertTrue('Cant remove absolute path' in str(ex))
             hit_exception = True
         self.assertTrue(hit_exception)
+
+        my_file = backend.open('/a/b/d', mode)
         set_config_name('test_configs/posix-id2filename.cfg')
-        my_file = backend.open(47, mode)
+        my_file = backend.open(12345, mode)
         set_config_name('config.cfg')
 
     def test_posix_backend_close(self):

--- a/archiveinterface/archivebackends/abstract/abstract_backend_archive.py
+++ b/archiveinterface/archivebackends/abstract/abstract_backend_archive.py
@@ -25,6 +25,8 @@ class AbstractBackendArchive(object):
 
         Method that opens a file for the backend archive that implements
         this class Should return a file like object, most likely self.
+        This method is also responsible for making sure the dirname of
+        the filepath exists before trying to open.
         """
         pass
 

--- a/archiveinterface/archivebackends/hpss/hpssExtensions.c
+++ b/archiveinterface/archivebackends/hpss/hpssExtensions.c
@@ -291,14 +291,18 @@ rec_makedirs(char *filepath)
         filep_copy = strdup(filepath);
         dirname_str = dirname(filep_copy);
         err = rec_makedirs(dirname_str);
-        free(filep_copy);
-        if(err == NULL)
+        if(err == NULL) {
+            free(filep_copy);
             return NULL;
-        hpss_err = hpss_Mkdir(dirname_str, 0755);
+        }
+        hpss_err = hpss_Mkdir(filepath, 0755);
         if(hpss_err != 0) {
+            perror("mkdir");
+            free(filep_copy);
             PyErr_SetString(archiveInterfaceError, "Unable to mkdir.");
             return NULL;
         }
+        free(filep_copy);
     }
     Py_RETURN_NONE;
 }

--- a/archiveinterface/archivebackends/hpss/hpssExtensions.c
+++ b/archiveinterface/archivebackends/hpss/hpssExtensions.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <time.h>
 #include <stdlib.h>
+#include <libgen.h>
 #include "hpss_api.h"
 #include <sys/types.h>
 #include <utime.h>
@@ -270,6 +271,50 @@ pacifica_archiveinterface_utime(PyObject *self, PyObject *args)
 }
 
 
+static PyObject *
+rec_makedirs(char *filepath)
+{
+    char *dirname_str;
+    char *filep_copy;
+    hpss_stat_t hpss_fstat;
+    PyObject *err;
+    int hpss_err;
+    hpss_err = hpss_Stat(filepath, &hpss_fstat);
+    if(hpss_err == 0) {
+        if(S_ISDIR(hpss_fstat.st_mode)) {
+            Py_RETURN_NONE;
+        } else {
+            PyErr_SetString(archiveInterfaceError, "File is not a directory.");
+            return NULL;
+        }
+    } else {
+        filep_copy = strdup(filepath);
+        dirname_str = dirname(filep_copy);
+        err = rec_makedirs(dirname_str);
+        free(filep_copy);
+        if(err == NULL)
+            return NULL;
+        hpss_err = hpss_Mkdir(dirname_str, 0755);
+        if(hpss_err != 0) {
+            PyErr_SetString(archiveInterfaceError, "Unable to mkdir.");
+            return NULL;
+        }
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+pacifica_archiveinterface_makedirs(PyObject *self, PyObject *args)
+{
+    char *filepath;
+    if (!PyArg_ParseTuple(args, "s", &filepath))
+    {
+        PyErr_SetString(archiveInterfaceError, "Error parsing arguments");
+        return NULL;
+    }
+    return rec_makedirs(filepath);
+}
+
 static PyMethodDef StatusMethods[] = {
     {"hpss_status", pacifica_archiveinterface_status, METH_VARARGS,
         "Get the status for a file in the archive."},
@@ -285,6 +330,8 @@ static PyMethodDef StatusMethods[] = {
         "Stage a file to disk within hpss"},
     {"hpss_utime", pacifica_archiveinterface_utime, METH_VARARGS,
         "Set the modified time on a file"},
+    {"hpss_makedirs", pacifica_archiveinterface_makedirs, METH_VARARGS,
+        "Make a recursive directory tree"},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/archiveinterface/archivebackends/hpss/hpss_backend_archive.py
+++ b/archiveinterface/archivebackends/hpss/hpss_backend_archive.py
@@ -93,6 +93,7 @@ class HpssBackendArchive(AbstractBackendArchive):
             self._filepath = filename
             hpss = HpssExtended(self._filepath, self._latency)
             hpss.ping_core()
+            hpss.makedirs()
             hpss_fopen = self._hpsslib.hpss_Fopen
             hpss_fopen.restype = c_void_p
             self._file = hpss_fopen(filename, mode)

--- a/archiveinterface/archivebackends/hpss/hpss_extended.py
+++ b/archiveinterface/archivebackends/hpss/hpss_extended.py
@@ -3,6 +3,7 @@
 
 Module that holds the class to the interface for the hpss c extensions.
 """
+from os.path import dirname
 # c extension import not picked up by pylint, so disabling
 # pylint: disable=import-error
 # pylint: disable=no-name-in-module
@@ -106,5 +107,15 @@ class HpssExtended(object):
         except Exception as ex:
             # Push the excpetion up the chain to the response
             err_str = 'Error using c extension for hpss utime'\
+                      ' exception: ' + str(ex)
+            raise ArchiveInterfaceError(err_str)
+
+    def makedirs(self):
+        """Recursively make the directories for the filepath."""
+        try:
+            _hpssExtensions.hpss_makedirs(dirname(self._filepath))
+        except Exception as ex:
+            # Push the excpetion up the chain to the response
+            err_str = 'Error using c extension for hpss makedirs'\
                       ' exception: ' + str(ex)
             raise ArchiveInterfaceError(err_str)

--- a/archiveinterface/archivebackends/oracle_hms_sideband/hms_sideband_backend_archive.py
+++ b/archiveinterface/archivebackends/oracle_hms_sideband/hms_sideband_backend_archive.py
@@ -40,8 +40,7 @@ class HmsSidebandBackendArchive(AbstractBackendArchive):
         """Open a hms sideband file."""
         # want to close any open files first
         try:
-            if self._file:
-                self.close()
+            self.close()
         except ArchiveInterfaceError as ex:
             err_str = "Can't close previous HMS Sideband file before opening new "\
                       'one with error: ' + str(ex)
@@ -51,6 +50,9 @@ class HmsSidebandBackendArchive(AbstractBackendArchive):
             filename = os.path.join(self._prefix, path_info_munge(self._fpath))
             # path database refers to, rather then just the file system mount path
             sam_qfs_path = os.path.join(self._sam_qfs_prefix, path_info_munge(self._fpath))
+            dirname = os.path.dirname(sam_qfs_path)
+            if not os.path.isdir(dirname):
+                os.makedirs(dirname, 0755)
             self._file = ExtendedHmsSideband(filename, mode, sam_qfs_path)
             return self
         except Exception as ex:

--- a/archiveinterface/archivebackends/posix/posix_backend_archive.py
+++ b/archiveinterface/archivebackends/posix/posix_backend_archive.py
@@ -43,6 +43,9 @@ class PosixBackendArchive(AbstractBackendArchive):
             else:
                 fpath = un_abs_path(filepath)
             filename = os.path.join(self._prefix, fpath)
+            dirname = os.path.dirname(filename)
+            if not os.path.isdir(dirname):
+                os.makedirs(dirname, 0755)
             self._file = ExtendedFile(filename, mode)
             return self
         except Exception as ex:

--- a/archiveinterface/archivebackends/posix/posix_backend_archive.py
+++ b/archiveinterface/archivebackends/posix/posix_backend_archive.py
@@ -26,22 +26,21 @@ class PosixBackendArchive(AbstractBackendArchive):
         super(PosixBackendArchive, self).__init__(prefix)
         self._prefix = prefix
         self._file = None
+        self._id2filename = lambda x: x
+        if read_config_value('posix', 'use_id2filename') == 'true':
+            self._id2filename = lambda x: id2filename(int(x))
 
     def open(self, filepath, mode):
         """Open a posix file."""
         # want to close any open files first
         try:
-            if self._file:
-                self.close()
+            self.close()
         except ArchiveInterfaceError as ex:
             err_str = "Can't close previous posix file before opening new "\
                       'one with error: ' + str(ex)
             raise ArchiveInterfaceError(err_str)
         try:
-            if read_config_value('posix', 'use_id2filename') == 'true':
-                fpath = un_abs_path(id2filename(int(filepath)))
-            else:
-                fpath = un_abs_path(filepath)
+            fpath = un_abs_path(self._id2filename(filepath))
             filename = os.path.join(self._prefix, fpath)
             dirname = os.path.dirname(filename)
             if not os.path.isdir(dirname):


### PR DESCRIPTION
### Description

This adds mkdir -p options to allow for creating more complex paths.
### Issues Resolved

#27 
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
