### PR TITLE
fix up Docker containers to not use `-onbuild`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
-from centos:centos6
+from python:2
 
-RUN yum -y update && \
-    yum -y install http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm && \
-    yum -y install MySQL-python && \
-    yum -y install python-wsgi python-pip wget curl unzip gcc glibc-devel python-devel python-argparse && \
-    yum -y clean all
-RUN mkdir /app
-COPY . /app
-WORKDIR /app
+WORKDIR /usr/src/app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir uwsgi
+COPY . .
 RUN python ./setup.py install
-ENV PACIFICA_AAPI_BACKEND_TYPE posix
-ENV PACIFICA_AAPI_ADDRESS 0.0.0.0
-ENV PACIFICA_AAPI_PORT 8080
-ENV PACIFICA_AAPI_PREFIX /srv
-EXPOSE 8080
-ENTRYPOINT [ "/bin/bash", "/app/entrypoint.sh" ]
+ENV PAI_BACKEND_TYPE posix
+ENV PAI_PREFIX /srv
+ENV ARCHIVEI_CONFIG /usr/src/app/config.cfg
+ENTRYPOINT [ "/bin/bash", "/usr/src/app/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-python ./scripts/archiveinterfaceserver.py \
-  -t $PACIFICA_AAPI_BACKEND_TYPE \
-  -p $PACIFICA_AAPI_PORT \
-  -a $PACIFICA_AAPI_ADDRESS \
-  --prefix $PACIFICA_AAPI_PREFIX \
-  "$@"
+cd /
+uwsgi \
+  --http-socket $PACIFICA_AAPI_ADDRESS:$PACIFICA_AAPI_PORT \
+  --master \
+  --die-on-term \
+  --wsgi-file /usr/src/app/archiveinterface/wsgi.py "$@"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ coverage>4.0,<4.4
 peewee
 pre-commit
 pylint
+PyMySQL
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 peewee
+PyMySQL
 setuptools


### PR DESCRIPTION
### Description

This removes the `-onbuild` variant of the dockerfile and includes some more scalable wsgi server configuration.
### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
