### PR TITLE
fix adding back the entrypoint variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN pip install --no-cache-dir uwsgi
 COPY . .
 RUN python ./setup.py install
 ENV PAI_BACKEND_TYPE posix
+ENV PACIFICA_AAPI_ADDRESS 0.0.0.0
+ENV PACIFICA_AAPI_PORT 8080
 ENV PAI_PREFIX /srv
 ENV ARCHIVEI_CONFIG /usr/src/app/config.cfg
 ENTRYPOINT [ "/bin/bash", "/usr/src/app/entrypoint.sh" ]


### PR DESCRIPTION
### Description

We need to add back the two env vars the entrypoint uses
### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
