### PR TITLE
change this to setuptools not distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from os.path import isfile
 # pylint: disable=no-name-in-module
 # pylint: disable=import-error
-from distutils.core import Extension
+from setuptools.extension import Extension
 # pylint: enable=import-error
 # pylint: enable=no-name-in-module
 from setuptools import setup, find_packages


### PR DESCRIPTION
### Description

We should use setuptools all the way not distutils
### Issues Resolved

N/A
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
