### PR TITLE
We should use configparser in python 3 and getboolean

### DIFF
--- a/pacifica/archiveinterface/backends/posix/archive.py
+++ b/pacifica/archiveinterface/backends/posix/archive.py
@@ -30,7 +30,7 @@ class PosixBackendArchive(AbstractBackendArchive):
         self._file = None
         self._filepath = None
         self._id2filename = lambda x: x
-        if get_config().get('posix', 'use_id2filename') == 'true':
+        if get_config().getboolean('posix', 'use_id2filename'):
             self._id2filename = lambda x: id2filename(int(x))
 
     def open(self, filepath, mode):

--- a/pacifica/archiveinterface/config.py
+++ b/pacifica/archiveinterface/config.py
@@ -4,7 +4,7 @@
 try:
     from ConfigParser import SafeConfigParser
 except ImportError:  # pragma: no cover python 2 vs 3 issue
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser as SafeConfigParser
 from pacifica.archiveinterface.globals import CONFIG_FILE
 
 


### PR DESCRIPTION
### Description

This is some quick fixes to use getboolean for grabing config for
id2filename in posix and use ConfigParser when python 3.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
