### PR TITLE
Fix the return type of the root request

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ install:
       C:\pacifica\Scripts\activate.ps1;
       python -m pip install --upgrade pip setuptools wheel;
       python -m pip install -r requirements-dev.txt;
+      echo 'Done';
 
 build: off
 

--- a/pacifica/archiveinterface/rest_generator.py
+++ b/pacifica/archiveinterface/rest_generator.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 import shutil
 from json import dumps
 import cherrypy
-from .archive_utils import get_http_modified_time, file_status
+from .archive_utils import get_http_modified_time, file_status, bytes_type
 from .exception import ArchiveInterfaceError
 
 BLOCK_SIZE = 1 << 20
@@ -48,7 +48,7 @@ class ArchiveInterfaceGenerator(object):
         # if asking for / then return a message that the archive is working
         if not args:
             cherrypy.response.headers['Content-Type'] = 'application/json'
-            return {'message': 'Pacifica Archive Interface Up and Running'}
+            return bytes_type(dumps({'message': 'Pacifica Archive Interface Up and Running'}))
         archivefile = self._archive.open(args[0], 'r')
         cherrypy.response.headers['Content-Type'] = 'application/octet-stream'
 

--- a/tests/interface_test.py
+++ b/tests/interface_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """File used to unit test the pacifica archive interface."""
+from json import loads
 import unittest
 import time
 from pacifica.archiveinterface.archive_utils import un_abs_path, get_http_modified_time
@@ -130,6 +131,6 @@ class TestArchiveGenerator(unittest.TestCase):
         factory = ArchiveBackendFactory()
         backend = factory.get_backend_archive('posix', '/tmp')
         generator = ArchiveInterfaceGenerator(backend)
-        jsn = generator.GET()
+        jsn = loads(generator.GET())
         self.assertEqual(
             jsn['message'], 'Pacifica Archive Interface Up and Running')


### PR DESCRIPTION
### Description

This fixes the return of hitting `/` with GET method. This actually returns the JSON object previously instead of just 'message'.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved
N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
