### PR TITLE
Fix #73 change error message to be more relavent

### DIFF
--- a/pacifica/archiveinterface/backends/hpss/archive.py
+++ b/pacifica/archiveinterface/backends/hpss/archive.py
@@ -251,6 +251,6 @@ class HpssBackendArchive(AbstractBackendArchive):
             )
         except Exception as ex:
             err_str = 'Can not rename hpss file {} to {} with error: {}'.format(
-                old_path, file_id, str(ex)
+                old_path, new_filepath, str(ex)
             )
             raise ArchiveInterfaceError(err_str)


### PR DESCRIPTION
### Description

This changes the error message when moving a file to show the two
file paths not the old path and the ID.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

Fix #73 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
