### PR TITLE
Fix the docs to be more current.

### DIFF
--- a/docs/exampleusage.md
+++ b/docs/exampleusage.md
@@ -73,7 +73,7 @@ The HTTP `POST` method is used to stage a file for use.  In posix this
 equates to a no-op on hpss it stages the file to the disk drive.
 
 ```
-curl -X POST http://127.0.0.1:8080/12345
+curl -X POST -d '' http://127.0.0.1:8080/12345
 ```
 
 Sample Output:
@@ -90,19 +90,14 @@ The upload file contains the path to current file on archive
 The Id at the end of the url is where the file will be moved to
 
 ```
-curl -X PATCH --upload-file /tmp/foo.json http://127.0.0.1:8080/2
-
+curl -X PATCH -H 'Content-Type: application/json' http://127.0.0.1:8080/123456 -d'{
+  "path": "/tmp/12345"
+}'
 ```
 
 Sample Output:
 ```
 {
     "message": "File Moved Successfully"
-}
-```
-Sample Upload File
-```
-{
-  "path": "/path/to/file/file.1"
 }
 ```

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     description='Pacifica Archive Interface',
-    url='https://pypi.python.org/pypi/pacifica-archiveinterface/',
+    url='https://github.com/pacifica/pacifica-archiveinterface/',
     long_description=open(path.join(
         path.abspath(path.dirname(__file__)),
         'README.md')).read(),


### PR DESCRIPTION
### Description

The POST example now requires an empty body for curl to send. The
docs have been updated to reflect it. This should fix #77.

The PATCH example could be condensed to a single command with a
single output to make things more clear. The content-type header
should also be sent to the server so it knows the body content.
This should fix #78

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

Fix #78 
Fix #77 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
