### PR TITLE
Fix #87 Add Env Vars for Post Deployment

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,8 +94,12 @@ There are a few global variables at the top of the file that need to be adjusted
 
 ```
 export ARCHIVE_URL='http://127.0.0.1:8080/'
+export LARGE_FILE_SIZE=$(( 1024 * 1024 * 1024))
+export MANY_FILES_TEST_COUNT=1000
 ```
  - ARCHIVE_URL is the URL to the newly deployed archive_interface
+ - LARGE_FILE_SIZE is the size of the large file to test with (default 1Gib)
+ - MANY_FILES_TEST_COUNT is the number of small files to spam (default 1000)
 
 ## Running
 

--- a/post_deployment_tests/deployment_test.py
+++ b/post_deployment_tests/deployment_test.py
@@ -180,7 +180,7 @@ class RandomFile(object):
 class LargeBinaryFileArchiveTests(unittest.TestCase):
     """Class that tests the writing and reading of a large binary file."""
 
-    large_file_size = 1024 * 1024 * 1024
+    large_file_size = int(os.getenv('LARGE_FILE_SIZE', 1024 * 1024 * 1024))
 
     def test_large_binary_file_write(self):
         """test writing a large binary file to the archive."""
@@ -258,7 +258,7 @@ class ManyFileArchiveTests(unittest.TestCase):
             new_thread.daemon = True
             new_thread.start()
 
-        for i in range(3000, 4000):
+        for i in range(3000, int(os.getenv('MANY_FILES_TEST_COUNT', 1000))+3000):
             job_id_queue.put(i)
 
         for i in range(num_worker_threads):


### PR DESCRIPTION
### Description

This adds environment variables to specify the size of the large
file and the total number of the many files test.

To set the size of the large file test and number of little files:
```
cd post_deployment_tests
export LARGE_FILE_SIZE=$(( 1024 * 1024 * 1024 * 1024))
export MANY_FILES_TEST_COUNT=10000
python -m unittest deployment_test
```

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #87 
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
