### PR TITLE
Add threaded get to multifile testing.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
             -   id: autopep8
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.2
+    rev: v2.2.3
     hooks:
             -   id: fix-encoding-pragma
             -   id: trailing-whitespace


### PR DESCRIPTION
### Description

This adds download of the threaded many file testing during post
deployment testing.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #88 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
