### PR TITLE
Fix #96 Add HPSS Latency as Config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from python:2
+from python:3.6
 
 WORKDIR /usr/src/app
 COPY . .

--- a/pacifica/archiveinterface/backends/hpss/archive.py
+++ b/pacifica/archiveinterface/backends/hpss/archive.py
@@ -68,7 +68,6 @@ class HpssBackendArchive(AbstractBackendArchive):
         self._file = None
         self._filepath = None
         self._hpsslib = None
-        self._latency = 5  # number not significant
         # need to load  the hpss libraries/ extensions
         try:
             self._hpsslib = cdll.LoadLibrary(HPSS_LIBRARY_PATH)
@@ -96,7 +95,7 @@ class HpssBackendArchive(AbstractBackendArchive):
             fpath = un_abs_path(filepath)
             self._filepath = filename = os.path.join(
                 self._prefix, path_info_munge(fpath))
-            hpss = HpssExtended(self._filepath, self._latency)
+            hpss = HpssExtended(self._filepath)
             hpss.ping_core(self._sitename)
             hpss.makedirs()
             hpss_fopen = self._hpsslib.hpss_Fopen
@@ -127,7 +126,7 @@ class HpssBackendArchive(AbstractBackendArchive):
         """Close an HPSS File."""
         try:
             if self._file:
-                hpss = HpssExtended(self._filepath, self._latency)
+                hpss = HpssExtended(self._filepath)
                 hpss.ping_core(self._sitename)
                 hpss_fflush = self._hpsslib.hpss_Fflush
                 hpss_fflush.restype = c_int
@@ -189,7 +188,7 @@ class HpssBackendArchive(AbstractBackendArchive):
         """Stage an hpss file to the top level drive."""
         try:
             if self._filepath:
-                hpss = HpssExtended(self._filepath, self._latency)
+                hpss = HpssExtended(self._filepath)
                 hpss.ping_core(self._sitename)
                 hpss.stage()
         except Exception as ex:
@@ -200,7 +199,7 @@ class HpssBackendArchive(AbstractBackendArchive):
         """Get the status of a file in the hpss archive."""
         try:
             if self._filepath:
-                hpss = HpssExtended(self._filepath, self._latency)
+                hpss = HpssExtended(self._filepath)
                 hpss.ping_core(self._sitename)
                 return hpss.status()
         except Exception as ex:
@@ -213,7 +212,7 @@ class HpssBackendArchive(AbstractBackendArchive):
         """Set the mod time for an hpss archive file."""
         try:
             if self._filepath:
-                hpss = HpssExtended(self._filepath, self._latency)
+                hpss = HpssExtended(self._filepath)
                 hpss.ping_core(self._sitename)
                 hpss.set_mod_time(mod_time)
         except Exception as ex:
@@ -224,7 +223,7 @@ class HpssBackendArchive(AbstractBackendArchive):
         """Set the file permissions for an hpss archive file."""
         try:
             if self._filepath:
-                hpss = HpssExtended(self._filepath, self._latency)
+                hpss = HpssExtended(self._filepath)
                 hpss.ping_core(self._sitename)
                 rcode = self._hpsslib.hpss_Chmod(self._filepath.encode('utf8'), 0o444)
                 self._check_rcode(

--- a/pacifica/archiveinterface/backends/hpss/extended.py
+++ b/pacifica/archiveinterface/backends/hpss/extended.py
@@ -16,14 +16,15 @@ except ImportError:
 # pylint: enable=no-name-in-module
 from .status import HpssStatus
 from ...exception import ArchiveInterfaceError
+from ...config import get_config
 
 
 class HpssExtended:
     """Provide the interface for the hpss ctypes."""
 
-    def __init__(self, filepath, accept_latency=5):
+    def __init__(self, filepath):
         """Constructor for the HPSS Extended File type."""
-        self._accept_latency = accept_latency
+        self._accept_latency = get_config().get('hpss', 'accept_latency')
         self._latency = None
         self._filepath = filepath
 

--- a/pacifica/archiveinterface/config.py
+++ b/pacifica/archiveinterface/config.py
@@ -1,10 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Configuration reading and validation module."""
-try:
-    from ConfigParser import SafeConfigParser
-except ImportError:  # pragma: no cover python 2 vs 3 issue
-    from configparser import ConfigParser as SafeConfigParser
+from configparser import ConfigParser as SafeConfigParser
 from pacifica.archiveinterface.globals import CONFIG_FILE
 
 
@@ -17,6 +14,7 @@ def get_config():
     configparser.set('hpss', 'user', 'hpss.unix')
     configparser.set('hpss', 'auth', '/var/hpss/etc/hpss.unix.keytab')
     configparser.set('hpss', 'sitename', 'example.com')
+    configparser.set('hpss', 'accept_latency', '5')
     configparser.add_section('hsm_sideband')
     configparser.set('hsm_sideband', 'sam_qfs_prefix', '/data/pacifica/test/')
     configparser.set('hsm_sideband', 'schema', 'samqfs1db')


### PR DESCRIPTION
### Description

This adds a config option `accept_latency` for the `hpss` section
that's set by default to 5. This defines the acceptable latency to
the HPSS backend services.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #96 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
