### PR TITLE
Fix #102 get an integer for HPSS latency

### DIFF
--- a/pacifica/archiveinterface/backends/hpss/extended.py
+++ b/pacifica/archiveinterface/backends/hpss/extended.py
@@ -24,7 +24,7 @@ class HpssExtended:
 
     def __init__(self, filepath):
         """Constructor for the HPSS Extended File type."""
-        self._accept_latency = get_config().get('hpss', 'accept_latency')
+        self._accept_latency = get_config().getint('hpss', 'accept_latency')
         self._latency = None
         self._filepath = filepath
 


### PR DESCRIPTION
### Description

This casts the config value for the HPSS latency as an integer.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #102
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
