### PR TITLE
Add Seek and Byte Range Options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.4
+    rev: v1.5
     hooks:
             -   id: autopep8
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
             -   id: fix-encoding-pragma
             -   id: trailing-whitespace

--- a/pacifica/archiveinterface/backends/abstract/archive.py
+++ b/pacifica/archiveinterface/backends/abstract/archive.py
@@ -46,6 +46,14 @@ class AbstractBackendArchive:
         """
 
     @abc.abstractmethod
+    def seek(self, offset):
+        """Seek to an offset in the file.
+
+        Method that seeks to an offset in the file for the backend
+        archive that implements this class.
+        """
+
+    @abc.abstractmethod
     def write(self, buf):
         """Write File.
 

--- a/pacifica/archiveinterface/backends/hpss/archive.py
+++ b/pacifica/archiveinterface/backends/hpss/archive.py
@@ -169,6 +169,13 @@ class HpssBackendArchive(AbstractBackendArchive):
         err_str = 'Internal file path invalid'
         raise ArchiveInterfaceError(err_str)
 
+    def seek(self, offset):
+        """Seek in the file to offset."""
+        hpss_fseek = self._hpsslib.hpss_Fseek
+        hpss_fseek.restype = c_long
+        hpss_fseek.argtypes = [c_void_p, c_long, c_int]
+        hpss_fseek(self._file, SEEK_SET, offset)
+
     def write(self, buf):
         """Write a file to the hpss archive."""
         try:

--- a/pacifica/archiveinterface/backends/oracle_hsm_sideband/archive.py
+++ b/pacifica/archiveinterface/backends/oracle_hsm_sideband/archive.py
@@ -82,7 +82,18 @@ class HsmSidebandBackendArchive(AbstractBackendArchive):
             if self._file:
                 return self._file.read(blocksize)
         except Exception as ex:
-            err_str = "Can't read HSM SIdeband file with error: " + str(ex)
+            err_str = "Can't read HSM Sideband file with error: " + str(ex)
+            raise ArchiveInterfaceError(err_str)
+        err_str = 'Internal file handle invalid'
+        raise ArchiveInterfaceError(err_str)
+
+    def seek(self, offset):
+        """Seek in the file to the offset."""
+        try:
+            if self._file:
+                return self._file.seek(offset)
+        except Exception as ex:
+            err_str = "Can't seek HSM Sideband file with error: " + str(ex)
             raise ArchiveInterfaceError(err_str)
         err_str = 'Internal file handle invalid'
         raise ArchiveInterfaceError(err_str)

--- a/pacifica/archiveinterface/backends/posix/archive.py
+++ b/pacifica/archiveinterface/backends/posix/archive.py
@@ -76,6 +76,17 @@ class PosixBackendArchive(AbstractBackendArchive):
         err_str = 'Internal file handle invalid'
         raise ArchiveInterfaceError(err_str)
 
+    def seek(self, offset):
+        """Seek in the file to the offset."""
+        try:
+            if self._file:
+                return self._file.seek(offset)
+        except Exception as ex:
+            err_str = "Can't seek posix file with error: " + str(ex)
+            raise ArchiveInterfaceError(err_str)
+        err_str = 'Internal file handle invalid'
+        raise ArchiveInterfaceError(err_str)
+
     def write(self, buf):
         """Write a posix file to the archive."""
         try:

--- a/pacifica/archiveinterface/rest_generator.py
+++ b/pacifica/archiveinterface/rest_generator.py
@@ -47,6 +47,7 @@ class ArchiveInterfaceGenerator:
             start = int(start)
             finish = int(finish)
         except ValueError:
+            archivefile.close()
             raise ArchiveInterfaceError(
                 'Invalid byte range format (int-int) given {}'.format(byte_range)
             )

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     long_description_content_type='text/markdown',
     author='David Brown',
     author_email='david.brown@pnnl.gov',
-    packages=find_packages(),
+    packages=find_packages(include='pacifica.*'),
     namespace_packages=['pacifica'],
     entry_points={
         'console_scripts': [

--- a/tests/cherrypy_test.py
+++ b/tests/cherrypy_test.py
@@ -72,6 +72,22 @@ class ArchiveInterfaceCPTest(helper.CPWebCase, SetupTearDown):
         data = resp.raw.read()
         self.assertEqual(len(data), BLOCK_SIZE+1, '{} does not equal {}'.format(len(data), BLOCK_SIZE+1))
 
+    def test_byte_range_error(self):
+        """Test the byte range error code."""
+        resp = requests.put(
+            '{}/5432'.format(self.url),
+            data='0'*20
+        )
+        self.assertEqual(resp.status_code, 201)
+        resp = requests.get(
+            '{}/5432'.format(self.url),
+            params={'byte_range': 'blah-blah'},
+            stream=True
+        )
+        self.assertEqual(resp.status_code, 500)
+        self.assertTrue(
+            'Invalid byte range format' in resp.json()['traceback'])
+
     def test_error_interface(self):
         """Test some error states."""
         resp = requests.get('{}/12345'.format(self.url), stream=True)

--- a/tests/common_setup_test.py
+++ b/tests/common_setup_test.py
@@ -16,6 +16,7 @@ class SetupTearDown:
             '{}{}'.format(sep, join('tmp', '1234')),
             '{}{}'.format(sep, join('tmp', '1235')),
             '{}{}'.format(sep, join('tmp', 'cptests', '1235')),
+            '{}{}'.format(sep, join('tmp', 'cptests', '5432')),
             '{}{}'.format(sep, join('tmp', '12345')),
             '{}{}'.format(sep, join('tmp', '5678')),
             '{}{}'.format(sep, join('tmp', '15', 'cd', '5b', '75bcd15')),

--- a/tests/posix_failure_test.py
+++ b/tests/posix_failure_test.py
@@ -92,6 +92,22 @@ class TestPosixBackendArchive(unittest.TestCase, SetupTearDown):
         self.assertTrue("Can't read posix file with error" in str(exc.exception))
         backend.close()
 
+    def test_posix_backend_failed_seek(self):
+        """Test seeking to a failed file."""
+        backend = PosixBackendArchive('/tmp/')
+        backend.open('1234', 'w')
+        backend.close()
+        backend.open('1234', 'r')
+
+        # easiest way to unit test is look at class variable
+        # pylint: disable=protected-access
+        backend._file.seek = mock.MagicMock(side_effect=IOError('Unable to Seek!'))
+        # pylint: enable=protected-access
+        with self.assertRaises(ArchiveInterfaceError) as exc:
+            backend.seek(0)
+        self.assertTrue("Can't seek posix file with error" in str(exc.exception))
+        backend.close()
+
     def test_posix_backend_failed_fd(self):
         """Test reading to a failed file fd."""
         backend = PosixBackendArchive('/tmp/')
@@ -113,6 +129,9 @@ class TestPosixBackendArchive(unittest.TestCase, SetupTearDown):
         self.assertTrue('Internal file handle invalid' in str(exc.exception))
         with self.assertRaises(ArchiveInterfaceError) as exc:
             backend.status()
+        self.assertTrue('Internal file handle invalid' in str(exc.exception))
+        with self.assertRaises(ArchiveInterfaceError) as exc:
+            backend.seek(0)
         self.assertTrue('Internal file handle invalid' in str(exc.exception))
 
     def test_posix_backend_failed_stage(self):

--- a/tests/posix_test.py
+++ b/tests/posix_test.py
@@ -68,7 +68,7 @@ class TestPosixBackendArchive(unittest.TestCase, SetupTearDown):
         mode = 'w'
         my_file = backend.open('/a/b/d', mode)
         temp_cfg_file = pa_config.CONFIG_FILE
-        pa_config.CONFIG_FILE = 'test_configs/posix-id2filename.cfg'
+        pa_config.CONFIG_FILE = os.path.join(os.path.dirname(__file__), 'test_configs', 'posix-id2filename.cfg')
         backend = PosixBackendArchive('/tmp')
         my_file = backend.open(12345, mode)
         my_file.write('this is file 12345')
@@ -153,3 +153,15 @@ class TestPosixBackendArchive(unittest.TestCase, SetupTearDown):
         backend.patch('5678', '/tmp/1234')
         # Error would be thrown on patch so nothing to assert
         self.assertEqual(old_path, '/tmp/1234')
+
+
+    def test_seek(self):
+        """Test patching file."""
+        backend = PosixBackendArchive('/tmp')
+        my_file = backend.open('1234', 'w')
+        my_file.write('something')
+        my_file.close()
+        my_file = backend.open('1234', 'r')
+        my_file.seek(4)
+        data = my_file.read(-1).decode('utf8')
+        self.assertEqual(data, 'thing')

--- a/tests/posix_test.py
+++ b/tests/posix_test.py
@@ -154,7 +154,6 @@ class TestPosixBackendArchive(unittest.TestCase, SetupTearDown):
         # Error would be thrown on patch so nothing to assert
         self.assertEqual(old_path, '/tmp/1234')
 
-
     def test_seek(self):
         """Test patching file."""
         backend = PosixBackendArchive('/tmp')


### PR DESCRIPTION
### Description

This adds seek to the backend file storage mechanism and byte
range to the REST API.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

Fix #103 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
